### PR TITLE
make config and template root paths variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ You can pass the following environment variables to the container.
 | PROMETHEUS_HOST | Host of Prometheus monitoring. Default: 127.0.0.1. |
 | PROMETHEUS_PORT | Port of Prometheus monitoring. Default: 12798. |
 | RESOLVE_HOSTNAMES | Resolve topology hostnames to IP-addresses. Default: False. |
+| CONFIG_OUTPUT_ROOT_PATH | Root path for config files. Default: /config |
+| CONFIG_TEMPLATES_ROOT_PATH | Root path for template files. Default: /cfg-templates |
 | REPLACE_EXISTING_CONFIG | Reset and replace existing configs. Default: False. |
 | POOL_PLEDGE | Pledge (lovelace). Default: 100000000000 |
 | POOL_COST | Operational costs per epoch (lovelace). Default: 10000000000 |

--- a/scripts/init_config.py
+++ b/scripts/init_config.py
@@ -6,8 +6,8 @@ import json
 import socket
 import time
 
-CONFIG_TEMPLATES_ROOT_PATH = '/cfg-templates/'
-CONFIG_OUTPUT_ROOT_PATH = '/config/'
+CONFIG_TEMPLATES_ROOT_PATH = os.environ.get('CONFIG_TEMPLATES_ROOT_PATH', '/cfg-templates/')
+CONFIG_OUTPUT_ROOT_PATH = os.environ.get('CONFIG_OUTPUT_ROOT_PATH', '/config/')
 
 def slugify(value):
     """


### PR DESCRIPTION
This allows the user to change the two root paths used through environment variables. The change is backwards compatible.