### PR TITLE
fix conway-genesis.json

### DIFF
--- a/cfg-templates/main/conway-genesis.json
+++ b/cfg-templates/main/conway-genesis.json
@@ -1,3 +1,3 @@
 {
-    "genDelegs": {}
+  "genDelegs": {}
 }


### PR DESCRIPTION
2 spaces instead of 4 to match `f28f1c1280ea0d32f8cd3143e268650d6c1a8e221522ce4a7d20d62fc09783e1`

See original file for reference: https://github.com/input-output-hk/cardano-node/blob/master/configuration/cardano/mainnet-conway-genesis.json