### PR TITLE
add optional cron pulling cexplorer stats for prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ You can pass the following environment variables to the container.
 | PUBLIC_RELAY_PORT | Public port of Relay node. <br/><br/>Values:<br/>\<Any Port\><br/>If PUBLIC_RELAY_IP=TOPOLOGY the PUBLIC_RELAY_PORT will also be updated accordingly.<br/>Default: First entry of the topology. |
 | AUTO_TOPOLOGY | Automatically update topology.json. Default: True |
 | CNCLI_SYNC | Synchronize CNCLI. Default: True |
+| CEXPLORER_STATS | Daily cronjob to pull stats from cexplorer.io for prometheus node exporter. Default: False |
 | STATUS_PANEL | Split screen with cardano-node and status panel. Default: False |
 | PT_API_KEY | Pooltool.io API key |
 | PT_SENDTIP | Send tip to pooltool.io. Requires PT_API_KEY. Default: False |

--- a/cfg-templates/crontab
+++ b/cfg-templates/crontab
@@ -1,2 +1,0 @@
-30 * * * * /scripts/topology_submit
-45 * * * * /scripts/topology_update

--- a/scripts/cexplorer_pool_stats
+++ b/scripts/cexplorer_pool_stats
@@ -1,0 +1,10 @@
+#!/bin/bash -l
+
+source /scripts/init_node_vars
+
+POOL_ID=$(bech32 pool <<< $(cat ${NODE_PATH}/staking/POOL_ID))
+
+POOL_STATS_DIR=${NODE_PATH}/pool_stats
+mkdir -p POOL_STATS_DIR
+
+curl https://js.cexplorer.io/api-static/pool/${POOL_ID}.json 2>/dev/null | jq '.data' | jq 'del(.stats, .url , .img, .updated, .handles, .pool_id, .name, .pool_id_hash)' | tr -d \\\"{},: | awk NF | sed -e 's/^[ \t]*/cexplorer_/' > ${POOL_STATS_DIR}/cexplorer.prom

--- a/scripts/functions/auto_topology
+++ b/scripts/functions/auto_topology
@@ -1,5 +1,0 @@
-function auto_topology {
-    cp /cfg-templates/crontab /crontab
-    service cron start
-    crontab /crontab
-}

--- a/scripts/functions/ensure_cron_running
+++ b/scripts/functions/ensure_cron_running
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+function ensure_cron_running {
+  crontab /crontab
+  service cron start
+}

--- a/scripts/functions/run_stakingnode
+++ b/scripts/functions/run_stakingnode
@@ -18,8 +18,13 @@ function run_stakingnode {
             # Add to crontab
             echo "0 21 * * * every_five_days && leaderlogs_cncli next" >> /crontab
             echo "55 21 * * * every_five_days && send_slots" >> /crontab
-            crontab /crontab
+            ensure_cron_running
         fi
+    fi
+
+    if [[ $CEXPLORER_STATS = "True" ]]; then
+        echo "0 0 * * * /scripts/cexplorer_pool_stats" >> /crontab
+        ensure_cron_running
     fi
 
     # Running in loop allows for restarting without restarting the container

--- a/scripts/start-cardano-node
+++ b/scripts/start-cardano-node
@@ -141,9 +141,9 @@ if [ -n "$START_NODE" ]; then
         fi
 
         if [[ $AUTO_TOPOLOGY = "True" ]]; then
-            cp /cfg-templates/crontab /crontab
-            service cron start
-            crontab /crontab
+            echo "30 * * * * /scripts/topology_submit" >> /crontab
+            echo "45 * * * * /scripts/topology_update" >> /crontab
+            ensure_cron_running
         fi
 
         source /scripts/functions/run_node


### PR DESCRIPTION
* adding optional cron pulling cexplorer stats for prometheus. Passing `CEXPLORER_STATS=True` to the container installs a cronjob pulling pool stats (e.g. active/live stake, delegators, pledge, ...) from cexplorer.io API and exports to a file `pool_stats/cexplorer.prom` readable by prometheus/node_exporter textfile collector.

* adding `ensure_cron_running` function to ensure cron is actually running in any scenario
* Deleting obsolete `cfg-templates/crontab` file.

---
The cexplorer stats can be exported with the node_exporter and consumed in grafana like this

<img width="177" alt="Screenshot 2023-07-30 at 00 29 28" src="https://github.com/abracadaniel/cardano-pool-docker/assets/342977/d68ed1c4-d9e9-4080-baa1-a31e0801d1fb">
