### PR TITLE
add missing source statement for ensure_cron_running

### DIFF
--- a/scripts/start-cardano-node
+++ b/scripts/start-cardano-node
@@ -7,6 +7,7 @@ source /scripts/init_node_vars
 source /scripts/functions/run_node
 source /scripts/functions/get_public_ip
 source /scripts/functions/init_config
+source /scripts/functions/ensure_cron_running
 
 function help {
     echo "Arguments:"


### PR DESCRIPTION
ensure_cron_running wasn't executed, therefore crontab wasn't configured or started either.