### PR TITLE
inject custom peers on client side, not through customPeers request param

### DIFF
--- a/scripts/functions/validations
+++ b/scripts/functions/validations
@@ -1,0 +1,30 @@
+# Borrowed from https://github.com/cardano-community/guild-operators
+# Thank you!
+
+# Description : Helper function to validate that input is a number
+#             : $1 = number
+isNumber() {
+    [[ -z $1 ]] && return 1
+    [[ $1 =~ ^[0-9]+$ ]] && return 0 || return 1
+}
+
+# Description : Helper function to validate IPv4 address
+#             : $1 = IP
+isValidIPv4() {
+    local ip=$1
+    [[ -z ${ip} ]] && return 1
+    if [[ ${ip} =~ ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ || ${ip} =~ ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9_\-]*[A-Za-z0-9])$ ]]; then
+    return 0
+    fi
+    return 1
+}
+
+# Description : Helper function to validate IPv6 address, works for normal IPv6 addresses, not dual incl IPv4
+#             : $1 = IP
+isValidIPv6() {
+    local ip=$1
+    [[ -z ${ip} ]] && return 1
+    ipv6_regex="^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
+    [[ ${ip} =~ ${ipv6_regex} ]] && return 0
+    return 1
+}

--- a/scripts/get_topology_str.py
+++ b/scripts/get_topology_str.py
@@ -6,5 +6,5 @@ if __name__ == '__main__':
 
     _topology = []
     for t in topology:
-        _topology.append('%s:%s:%s' % (t.get('addr'), t.get('port'), t.get('valency')))
+        _topology.append('%s,%s,%s' % (t.get('addr'), t.get('port'), t.get('valency')))
     print('|'.join(_topology))

--- a/scripts/topology_update
+++ b/scripts/topology_update
@@ -12,37 +12,64 @@ for i in "$@"; do
 done
 
 source /scripts/functions/get_public_ip
+source /scripts/functions/validations
 
-cd ${NODE_PATH}
+echo -n "Updating topology.json ... "
 
-echo -n "Updating topology.json ..."
-
+TOPOLOGY_FILE=${NODE_PATH}/topology.json
 NWMAGIC=$(jq -r .networkMagic < ${NODE_PATH}/shelley-genesis.json)
 CUSTOM_PEERS=$(python3 /scripts/get_topology_str.py)
 
-curl -s -o ${NODE_PATH}/topology.auto.json "https://api.clio.one/htopology/v1/fetch/?max=14&magic=${NWMAGIC}&customPeers=${CUSTOM_PEERS}"
-PRODUCERS=$(jq -r .Producers < ${NODE_PATH}/topology.auto.json)
+curl -s -f -o "${TOPOLOGY_FILE}".tmp "https://api.clio.one/htopology/v1/fetch/?max=14&magic=${NWMAGIC}"
+
+[[ ! -s "${TOPOLOGY_FILE}".tmp ]] && echo "ERROR: The downloaded topology file is empty!" && exit 1
+PRODUCERS=$(jq -r .Producers < "${TOPOLOGY_FILE}".tmp)
 
 if [[ "${PRODUCERS}" == "null" ]]; then
-    echo " ${CROSS_MARK} Error."
-    cat ${NODE_PATH}/topology.auto.json
+    echo "${CROSS_MARK} Error." && cat "${TOPOLOGY_FILE}".tmp
 
     if [[ -n "$RETRY" ]]; then
         echo "Submitting IP to topology updater database and retrying fetching the topology."
-        topology_submit
-        topology_update
+        topology_submit && topology_update
     fi
 else
-    # Replace topology
-    mv ${NODE_PATH}/topology.json ${NODE_PATH}/topology.backup.json
-    mv -f ${NODE_PATH}/topology.auto.json ${NODE_PATH}/topology.json
+    if [[ -n "${CUSTOM_PEERS}" ]]; then
+        topo="$(cat "${TOPOLOGY_FILE}".tmp)"
+        IFS='|' read -ra cpeers <<< "${CUSTOM_PEERS}"
+        for cpeer in "${cpeers[@]}"; do
+          IFS=',' read -ra cpeer_attr <<< "${cpeer}"
+          case ${#cpeer_attr[@]} in
+            2) addr="${cpeer_attr[0]}"
+               port=${cpeer_attr[1]}
+               valency=1 ;;
+            3) addr="${cpeer_attr[0]}"
+               port=${cpeer_attr[1]}
+               valency=${cpeer_attr[2]} ;;
+            *) echo "ERROR: Invalid Custom Peer definition '${cpeer}'. Please double check CUSTOM_PEERS definition"
+               exit 1 ;;
+          esac
+          if [[ ${addr} = *.* ]]; then
+            ! isValidIPv4 "${addr}" && echo "ERROR: Invalid IPv4 address or hostname '${addr}'. Please check CUSTOM_PEERS definition" && continue
+          elif [[ ${addr} = *:* ]]; then
+            ! isValidIPv6 "${addr}" && echo "ERROR: Invalid IPv6 address '${addr}'. Please check CUSTOM_PEERS definition" && continue
+          fi
+          ! isNumber ${port} && echo "ERROR: Invalid port number '${port}'. Please check CUSTOM_PEERS definition" && continue
+          ! isNumber ${valency} && echo "ERROR: Invalid valency number '${valency}'. Please check CUSTOM_PEERS definition" && continue
+          topo=$(jq '.Producers += [{"addr": $addr, "port": $port|tonumber, "valency": $valency|tonumber}]' --arg addr "${addr}" --arg port ${port} --arg valency ${valency} <<< "${topo}")
+        done
+        echo "${topo}" | jq -r . >/dev/null 2>&1 && echo "${topo}" > "${TOPOLOGY_FILE}".tmp
+    fi
 
-    echo -e " ${CHECK_MARK} Done."
+    # Replace topology
+    mv "${TOPOLOGY_FILE}" "${TOPOLOGY_FILE}".backup
+    mv -f "${TOPOLOGY_FILE}".tmp $TOPOLOGY_FILE
+
+    echo -e "${CHECK_MARK} Done."
 
     # Restart cardano-node
     if [[ -n "$AUTO_RESTART" ]]; then
-        echo -en "\nRestarting cardano-node ..."
+        echo -en "\nRestarting cardano-node ... "
         killall -9 cardano-node
-        echo -e " ${CHECK_MARK} Done."
+        echo -e "${CHECK_MARK} Done."
     fi
 fi


### PR DESCRIPTION
customPeers has been used to inject your local nodes into the topology list retrieved by clio API. It becomes a security concern when the relay connects to the block producer through a public IP as it exposes that IP to clio API (block producing IP is considered sensitive information).