### PR TITLE
fix db bootstrapping with mithril

### DIFF
--- a/scripts/download_db_snapshot
+++ b/scripts/download_db_snapshot
@@ -2,10 +2,10 @@
 
 source /scripts/init_node_vars
 
-mithril_config = "/cfg-templates/$CARDANO_NETWORK/mithril_config"
-$( cat "$mithril_config" | jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' )
+MITHRIL_CONFIG="/cfg-templates/$CARDANO_NETWORK/mithril_config.json"
+$( cat "$MITHRIL_CONFIG" | jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' )
 
 echo "Bootstrapping with latest Mithril snapshot"
-echo mithril-client snapshot show --digest latest
+echo `mithril-client snapshot show latest`
 
 mithril-client snapshot download --download-dir=$NODE_PATH latest


### PR DESCRIPTION
fixes syntax error and adds missing .json suffix to config file path