### PR TITLE
Update node version to 10.5.1

### DIFF
--- a/Dockerfile.bech32
+++ b/Dockerfile.bech32
@@ -1,7 +1,6 @@
-FROM haskell:9.8.2-slim AS build
+FROM haskell:9.12.2-slim-bookworm AS build
 WORKDIR /build
 RUN apt-get update && apt-get install --no-install-recommends -y build-essential git
-RUN stack upgrade
 
 # Install bech32
 ARG VERSION
@@ -12,7 +11,7 @@ RUN echo "Building tags/v$VERSION..." \
     && git tag \
     && git checkout tags/v$VERSION
 
-RUN stack setup --install-ghc \
+RUN stack setup 9.8.4 --install-ghc \
   && stack init \
   && stack build \
   && stack install --flag bech32:release

--- a/Dockerfile.cncli
+++ b/Dockerfile.cncli
@@ -22,6 +22,7 @@ RUN rustup install stable \
 
 # Install cncli
 ARG VERSION
+ARG DOCKER_USER="arradev"
 RUN echo "Building tags/v$VERSION..." \
     && git clone --recurse-submodules https://github.com/cardano-community/cncli \
     && cd cncli \
@@ -32,7 +33,7 @@ RUN echo "Building tags/v$VERSION..." \
     && cncli --version
 
 # Run
-FROM arradev/cardano-node:latest AS node
+FROM ${DOCKER_USER}/cardano-node:latest AS node
 
 FROM debian:stable-slim
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile.cncli
+++ b/Dockerfile.cncli
@@ -2,7 +2,7 @@ FROM debian:stable-slim AS build
 
 # Install build dependencies
 RUN apt-get update -y \
-    && apt-get install -y automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf musl-tools \
+    && apt-get install -y automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw6 libtool autoconf musl-tools \
     && apt-get install -y libsqlite3-dev m4 ca-certificates gcc libc6-dev curl \
     && apt-get clean
 

--- a/Dockerfile.mithril-signer
+++ b/Dockerfile.mithril-signer
@@ -13,7 +13,8 @@ RUN echo "Building tags/v$VERSION..." \
     && make build
 
 # Run
-FROM arradev/cardano-node:latest AS node
+ARG DOCKER_USER="arradev"
+FROM ${DOCKER_USER}/cardano-node:latest AS node
 FROM debian:stable-slim
 
 RUN apt-get update -y \

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,7 +2,7 @@ FROM debian:stable-slim AS build
 
 # Install build dependencies
 RUN apt-get update -y \
-    && apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf liblmdb-dev -y \
+    && apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw6 libtool autoconf liblmdb-dev -y \
     && apt-get install -y libsqlite3-dev m4 ca-certificates gcc libc6-dev curl \
     && apt-get clean
 

--- a/Dockerfile.pool
+++ b/Dockerfile.pool
@@ -14,7 +14,7 @@ WORKDIR /
 RUN apt-get update -y \
     && apt-get install -y libssl-dev vim procps dnsutils bc curl nano cron python3 python3-pip tmux jq wget lsof iproute2 \
     && apt-get clean
-RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED && pip3 install pytz
+RUN rm /usr/lib/python3.*/EXTERNALLY-MANAGED && pip3 install pytz
 
 # Copy compiled binaries
 COPY --from=node /bin/cardano* /bin/

--- a/Dockerfile.pool
+++ b/Dockerfile.pool
@@ -1,8 +1,9 @@
-FROM arradev/cardano-node:latest AS node
-FROM arradev/cardano-addresses:latest AS addresses
-FROM arradev/bech32:latest AS bech32
-FROM arradev/cncli:latest AS cncli
-FROM arradev/mithril-client:latest AS mithril-client
+ARG DOCKER_USER="arradev"
+FROM ${DOCKER_USER}/cardano-node:latest AS node
+FROM ${DOCKER_USER}/cardano-addresses:latest AS addresses
+FROM ${DOCKER_USER}/bech32:latest AS bech32
+FROM ${DOCKER_USER}/cncli:latest AS cncli
+FROM ${DOCKER_USER}/mithril-client:latest AS mithril-client
 FROM debian:stable-slim
 LABEL maintainer="droe@pm.me"
 

--- a/build.sh
+++ b/build.sh
@@ -7,38 +7,42 @@ ADDRESSES_VERSION="4.0.0"
 BECH_VERSION="1.1.7"
 CNCLI_VERSION="6.5.1"
 POOL_VERSION="10.4.1-2"
+DOCKER_USER="${DOCKER_USER:-arradev}"
 
 docker build -f Dockerfile.node \
     --build-arg VERSION=${NODE_VERSION} \
-    --tag arradev/cardano-node:${NODE_VERSION} \
-    --tag arradev/cardano-node:latest .
+    --tag ${DOCKER_USER}/cardano-node:${NODE_VERSION} \
+    --tag ${DOCKER_USER}/cardano-node:latest .
 
 docker build -f Dockerfile.mithril-client \
     --build-arg VERSION=${MITHRIL_VERSION} \
-    --tag arradev/mithril-client:${MITHRIL_VERSION} \
-    --tag arradev/mithril-client:latest .
+    --tag ${DOCKER_USER}/mithril-client:${MITHRIL_VERSION} \
+    --tag ${DOCKER_USER}/mithril-client:latest .
 
 docker build -f Dockerfile.mithril-signer \
     --build-arg VERSION=${MITHRIL_VERSION} \
-    --tag arradev/mithril-signer:${MITHRIL_VERSION} \
-    --tag arradev/mithril-signer:latest .
+    --build-arg DOCKER_USER=${DOCKER_USER} \
+    --tag ${DOCKER_USER}/mithril-signer:${MITHRIL_VERSION} \
+    --tag ${DOCKER_USER}/mithril-signer:latest .
 
 docker build -f Dockerfile.addresses \
     --build-arg VERSION=${ADDRESSES_VERSION} \
-    --tag arradev/cardano-addresses:${ADDRESSES_VERSION} \
-    --tag arradev/cardano-addresses:latest .
+    --tag ${DOCKER_USER}/cardano-addresses:${ADDRESSES_VERSION} \
+    --tag ${DOCKER_USER}/cardano-addresses:latest .
 
 docker build -f Dockerfile.bech32 \
     --build-arg VERSION=${BECH_VERSION} \
-    --tag arradev/bech32:${BECH_VERSION} \
-    --tag arradev/bech32:latest .
+    --tag ${DOCKER_USER}/bech32:${BECH_VERSION} \
+    --tag ${DOCKER_USER}/bech32:latest .
 
 docker build -f Dockerfile.cncli \
     --build-arg VERSION=${CNCLI_VERSION} \
-    --tag arradev/cncli:${CNCLI_VERSION} \
-    --tag arradev/cncli:latest .
+    --build-arg DOCKER_USER=${DOCKER_USER} \
+    --tag ${DOCKER_USER}/cncli:${CNCLI_VERSION} \
+    --tag ${DOCKER_USER}/cncli:latest .
 
 docker build -f Dockerfile.pool \
     --build-arg NODE_VERSION=${NODE_VERSION} \
-    --tag arradev/cardano-pool:${POOL_VERSION} \
-    --tag arradev/cardano-pool:latest .
+    --build-arg DOCKER_USER=${DOCKER_USER} \
+    --tag ${DOCKER_USER}/cardano-pool:${POOL_VERSION} \
+    --tag ${DOCKER_USER}/cardano-pool:latest .

--- a/scripts/download_db_snapshot
+++ b/scripts/download_db_snapshot
@@ -6,6 +6,6 @@ MITHRIL_CONFIG="/cfg-templates/$CARDANO_NETWORK/mithril_config.json"
 $( cat "$MITHRIL_CONFIG" | jq -r 'keys[] as $k | "export \($k)=\(.[$k])"' )
 
 echo "Bootstrapping with latest Mithril snapshot"
-echo `mithril-client snapshot show latest`
 
-mithril-client snapshot download --download-dir=$NODE_PATH latest
+mithril-client cardano-db snapshot show latest --json | python3 -m json.tool
+mithril-client cardano-db download --download-dir=$NODE_PATH latest


### PR DESCRIPTION
This PR updates the node version to 10.5.1, and also includes updating the container OS to the current latest debian (trixie) which required some smaller changes as well.

* Node update to 10.5.1
* Debian update to trixie
  * Python version 3.13

This PR also inludes a commit allowing for a different namespace for the docker images.